### PR TITLE
check_if_key_exists method improvement

### DIFF
--- a/Flutter---clean-localization-/clean_intl.py
+++ b/Flutter---clean-localization-/clean_intl.py
@@ -1,7 +1,9 @@
 import json, os, re
 
+
 def check_if_key_exists(key_name, dart_files):
-    pattern = re.compile(r'(S\s*\.\s*current\s*\.\s*' + key_name + '|S\s*\.\s*of\(context\)\s*\.\s*' + key_name + '|[\s+,:\[]s\s*\.\s*' + key_name + ')[\s.,():;\]\}]')
+    pattern = re.compile(
+        r'(S\s*\.\s*current\s*\.\s*' + key_name + '|S\s*\.\s*of\(context\)\s*\.\s*' + key_name + '|[\s+,:\[]s\s*\.\s*' + key_name + '|s\s*\.\s*' + key_name + ')[\s.,():;\]\}]')
     for file in dart_files:
         with open(file, 'r') as f:
             if pattern.search(f.read()):

--- a/Flutter---clean-localization-/clean_intl.py
+++ b/Flutter---clean-localization-/clean_intl.py
@@ -1,7 +1,7 @@
 import json, os, re
 
 def check_if_key_exists(key_name, dart_files):
-    pattern = re.compile(r'(S\s*\.\s*current\s*\.\s*' + key_name + '|S\s*\.\s*of\(context\)\s*\.\s*' + key_name + '|[\s+, \[, :]s\s*\.\s*' + key_name + ')[\s.,():;\]\}]')
+    pattern = re.compile(r'(S\s*\.\s*current\s*\.\s*' + key_name + '|S\s*\.\s*of\(context\)\s*\.\s*' + key_name + '|[\s+,:\[]s\s*\.\s*' + key_name + ')[\s.,():;\]\}]')
     for file in dart_files:
         with open(file, 'r') as f:
             if pattern.search(f.read()):

--- a/Flutter---clean-localization-/clean_intl.py
+++ b/Flutter---clean-localization-/clean_intl.py
@@ -3,10 +3,11 @@ import os
 
 
 def check_if_key_exists(key_name, dart_files):
+    pattern = re.compile(r'(S\s*\.\s*current\s*\.\s*' + key_name + '|S\s*\.\s*of\(context\)\s*\.\s*' + key_name + ')[\s.,():;\]\}]')
     for file in dart_files:
-        file_content = open(file, "r").read()
-        if key_name in file_content:
-            return True
+        with open(file, 'r') as f:
+            if pattern.search(f.read()):
+                return True
     return False
 
 

--- a/Flutter---clean-localization-/clean_intl.py
+++ b/Flutter---clean-localization-/clean_intl.py
@@ -1,9 +1,7 @@
-import json
-import os
-
+import json, os, re
 
 def check_if_key_exists(key_name, dart_files):
-    pattern = re.compile(r'(S\s*\.\s*current\s*\.\s*' + key_name + '|S\s*\.\s*of\(context\)\s*\.\s*' + key_name + ')[\s.,():;\]\}]')
+    pattern = re.compile(r'(S\s*\.\s*current\s*\.\s*' + key_name + '|S\s*\.\s*of\(context\)\s*\.\s*' + key_name + '|[\s+, \[, :]s\s*\.\s*' + key_name + ')[\s.,():;\]\}]')
     for file in dart_files:
         with open(file, 'r') as f:
             if pattern.search(f.read()):


### PR DESCRIPTION
I have improved check_if_key_exists not to just check if key_name exists in one of the files but to check if key_name exists after prefix "S.current." or "S.of(context).". It works even with newline and spaces between each of the elements.

e.g. These strings will be found:

"S.current.key_name"

"S.
current.
key_name"

"S
.
of(context)
.
key_name"